### PR TITLE
Accept all PKGEXTs supported by makepkg

### DIFF
--- a/archive.conf
+++ b/archive.conf
@@ -12,7 +12,7 @@ ARCHIVE_GROUP=archive
 
 # Package extensions
 PKGREGEX='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
-PKGSIG="$PKGREGEX\.sig"
+PKGSIGREGEX="$PKGREGEX\.sig"
 
 # Umask used when archiving
 UMASK=022

--- a/archive.conf
+++ b/archive.conf
@@ -11,8 +11,8 @@ ARCHIVE_USER=archive
 ARCHIVE_GROUP=archive
 
 # Package extensions
-PKGEXT='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
-PKGSIG="$PKGEXT.sig"
+PKGREGEX='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
+PKGSIG="$PKGREGEX.sig"
 
 # Umask used when archiving
 UMASK=022

--- a/archive.conf
+++ b/archive.conf
@@ -12,7 +12,7 @@ ARCHIVE_GROUP=archive
 
 # Package extensions
 PKGREGEX='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
-PKGSIG="$PKGREGEX.sig"
+PKGSIG="$PKGREGEX\.sig"
 
 # Umask used when archiving
 UMASK=022

--- a/archive.conf
+++ b/archive.conf
@@ -11,7 +11,7 @@ ARCHIVE_USER=archive
 ARCHIVE_GROUP=archive
 
 # Package extensions
-PKGEXT='.pkg.tar.?(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz)?'
+PKGEXT='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
 PKGSIG="$PKGEXT.sig"
 
 # Umask used when archiving

--- a/archive.conf
+++ b/archive.conf
@@ -11,7 +11,7 @@ ARCHIVE_USER=archive
 ARCHIVE_GROUP=archive
 
 # Package extensions
-PKGEXT='.pkg.tar.xz'
+PKGEXT='.pkg.tar.?(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz)?'
 PKGSIG="$PKGEXT.sig"
 
 # Umask used when archiving

--- a/archive.conf.test
+++ b/archive.conf.test
@@ -5,8 +5,8 @@ ARCHIVE_RSYNC='rsync://polymorf.fr/archlinux/'
 ARCHIVE_DIR="$PWD/archive-root"
 ARCHIVE_USER=$(id -u -n)
 ARCHIVE_GROUP=$(id -g -n)
-PKGEXT='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
-PKGSIG="$PKGEXT.sig"
+PKGREGEX='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
+PKGSIG="$PKGREGEX.sig"
 UMASK=022
 
 # Repositories

--- a/archive.conf.test
+++ b/archive.conf.test
@@ -5,7 +5,7 @@ ARCHIVE_RSYNC='rsync://polymorf.fr/archlinux/'
 ARCHIVE_DIR="$PWD/archive-root"
 ARCHIVE_USER=$(id -u -n)
 ARCHIVE_GROUP=$(id -g -n)
-PKGEXT='.pkg.tar.xz'
+PKGEXT='.pkg.tar.?(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz)?'
 PKGSIG="$PKGEXT.sig"
 UMASK=022
 

--- a/archive.conf.test
+++ b/archive.conf.test
@@ -6,7 +6,7 @@ ARCHIVE_DIR="$PWD/archive-root"
 ARCHIVE_USER=$(id -u -n)
 ARCHIVE_GROUP=$(id -g -n)
 PKGREGEX='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
-PKGSIG="$PKGREGEX\.sig"
+PKGSIGREGEX="$PKGREGEX\.sig"
 UMASK=022
 
 # Repositories

--- a/archive.conf.test
+++ b/archive.conf.test
@@ -5,7 +5,7 @@ ARCHIVE_RSYNC='rsync://polymorf.fr/archlinux/'
 ARCHIVE_DIR="$PWD/archive-root"
 ARCHIVE_USER=$(id -u -n)
 ARCHIVE_GROUP=$(id -g -n)
-PKGEXT='.pkg.tar.?(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz)?'
+PKGEXT='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
 PKGSIG="$PKGEXT.sig"
 UMASK=022
 

--- a/archive.conf.test
+++ b/archive.conf.test
@@ -6,7 +6,7 @@ ARCHIVE_DIR="$PWD/archive-root"
 ARCHIVE_USER=$(id -u -n)
 ARCHIVE_GROUP=$(id -g -n)
 PKGREGEX='\.pkg\.tar(\.(gz|bz2|xz|zst|lrz|lzo|Z|lz4|lz))?'
-PKGSIG="$PKGREGEX.sig"
+PKGSIG="$PKGREGEX\.sig"
 UMASK=022
 
 # Repositories

--- a/archive.sh
+++ b/archive.sh
@@ -54,7 +54,7 @@ load_config() {
 	msg "Loading configuration: $conf"
 	. "$conf" || fail 'Failed to load archive config.'
 	enforce_config_vars ARCHIVE_RSYNC ARCHIVE_DIR ARCHIVE_USER \
-		ARCHIVE_GROUP PKGEXT PKGSIG UMASK ARCHIVE_REPO ARCHIVE_ISO
+		ARCHIVE_GROUP PKGREGEX PKGSIG UMASK ARCHIVE_REPO ARCHIVE_ISO
 	if [[ $ARCHIVE_REPO == "1" ]]; then
 		enforce_config_vars REPO_DAYLY REPO_PACKAGES REPO_PACKAGES_INDEX \
 			REPO_PACKAGES_FULL_SEARCH REPO_RSYNC_TIMEOUT
@@ -157,7 +157,7 @@ repo_packages() {
 
 	# create new links pass
 	msg2 'creating new links'
-	find "$SCANDIR" -type f -regextype posix-extended -regex ".*$PKGEXT\$" -o -regex ".*$PKGSIG\$"| while read src; do
+	find "$SCANDIR" -type f -regextype posix-extended -regex ".*$PKGREGEX\$" -o -regex ".*$PKGSIG\$"| while read src; do
 	  filename="${src##*/}"
 	  pkgname="${filename%-*}" #remove arch and extension
 	  pkgname="${pkgname%-*}" #remove pkgrel
@@ -204,7 +204,7 @@ repo_packages_index() {
 	local TMPINDEX="$index_directory/.index.0.xz"
 
 	rm -f "$TMPINDEX"
-	find "$source_directory" -regextype posix-extended -regex ".*$PKGEXT\$" -printf '%f\n'|sed -E "s/$PKGEXT\$//"|sort -u|pacsort|xz -9 > "$TMPINDEX"
+	find "$source_directory" -regextype posix-extended -regex ".*$PKGREGEX\$" -printf '%f\n'|sed -E "s/$PKGREGEX\$//"|sort -u|pacsort|xz -9 > "$TMPINDEX"
 	if [[ ! -e "$INDEX" ]]; then
 	  mv "$TMPINDEX" "$INDEX"
 	elif diff -q "$INDEX" "$TMPINDEX"; then

--- a/archive.sh
+++ b/archive.sh
@@ -54,7 +54,7 @@ load_config() {
 	msg "Loading configuration: $conf"
 	. "$conf" || fail 'Failed to load archive config.'
 	enforce_config_vars ARCHIVE_RSYNC ARCHIVE_DIR ARCHIVE_USER \
-		ARCHIVE_GROUP PKGREGEX PKGSIG UMASK ARCHIVE_REPO ARCHIVE_ISO
+		ARCHIVE_GROUP PKGREGEX PKGSIGREGEX UMASK ARCHIVE_REPO ARCHIVE_ISO
 	if [[ $ARCHIVE_REPO == "1" ]]; then
 		enforce_config_vars REPO_DAYLY REPO_PACKAGES REPO_PACKAGES_INDEX \
 			REPO_PACKAGES_FULL_SEARCH REPO_RSYNC_TIMEOUT
@@ -157,7 +157,7 @@ repo_packages() {
 
 	# create new links pass
 	msg2 'creating new links'
-	find "$SCANDIR" -type f -regextype posix-extended -regex ".*$PKGREGEX\$" -o -regex ".*$PKGSIG\$"| while read src; do
+	find "$SCANDIR" -type f -regextype posix-extended -regex ".*$PKGREGEX\$" -o -regex ".*$PKGSIGREGEX\$"| while read src; do
 	  filename="${src##*/}"
 	  pkgname="${filename%-*}" #remove arch and extension
 	  pkgname="${pkgname%-*}" #remove pkgrel

--- a/archive.sh
+++ b/archive.sh
@@ -157,7 +157,7 @@ repo_packages() {
 
 	# create new links pass
 	msg2 'creating new links'
-	find "$SCANDIR" -type f -name "*$PKGEXT" -o -name "*$PKGSIG"| while read src; do
+	find "$SCANDIR" -type f -regextype posix-extended -regex ".*$PKGEXT\$" -o -regex ".*$PKGSIG\$"| while read src; do
 	  filename="${src##*/}"
 	  pkgname="${filename%-*}" #remove arch and extension
 	  pkgname="${pkgname%-*}" #remove pkgrel
@@ -204,7 +204,7 @@ repo_packages_index() {
 	local TMPINDEX="$index_directory/.index.0.xz"
 
 	rm -f "$TMPINDEX"
-	find "$source_directory" -name "*$PKGEXT" -printf '%f\n'|sed 's/.\{'${#PKGEXT}'\}$//'|sort -u|pacsort|xz -9 > "$TMPINDEX"
+	find "$source_directory" -regextype posix-extended -regex ".*$PKGEXT\$" -printf '%f\n'|sed -E "s/$PKGEXT\$//"|sort -u|pacsort|xz -9 > "$TMPINDEX"
 	if [[ ! -e "$INDEX" ]]; then
 	  mv "$TMPINDEX" "$INDEX"
 	elif diff -q "$INDEX" "$TMPINDEX"; then


### PR DESCRIPTION
This is required for the upcoming zstd migration.

archive-cleaner has not been patched yet and still hardcodes xz, i don't know python that well and would like someone else to take a look at that.