### PR TITLE
Modified archive-cleaner to support a list of extensions for packages

### DIFF
--- a/archive-cleaner
+++ b/archive-cleaner
@@ -17,9 +17,8 @@ from sys import stderr
 from libarchive import file_reader
 
 ARCHS = ['x86_64']
-PKG_EXT = '.tar.xz'
+PKG_EXTENSIONS = ['.tar.xz', '.tar.gz', '.tar.bz2', '.tar.zst', '.tar.lrz', '.tar.lzo', '.tar.Z', '.tar.lz4', '.tar.lz']
 SIG_EXT = '.sig'
-SOURCE_EXT = '.src.tar.gz'
 DEFAULT_ARCHIVE_DIR = '/srv/archive'
 DEFAULT_SOURCE_DIR = '/srv/ftp'
 SOURCE_WHITELIST = ['core', 'extra', 'staging', 'testing', 'community', 'community-staging', 'community-testing', 'multilib', 'multilib-staging', 'multilib-testing', 'gnome-unstable', 'kde-unstable']
@@ -32,10 +31,11 @@ def get_sourceball(path):
     date = m.group(0)
 
     pkgname = basename(path)
+    source_ext = '.src.{}'.format('.'.join(pkgname.split('.')[1:]))
     pkgver, pkgrel, _ = pkgname.split('-')[-3:]
     pkgname, _ = pkgname.split(f'-{pkgver}-{pkgrel}')
 
-    return f'/srv/archive/repos/{date}/sources/packages/{pkgname}-{pkgver}-{pkgrel}{SOURCE_EXT}'
+    return f'/srv/archive/repos/{date}/sources/packages/{pkgname}-{pkgver}-{pkgrel}{source_ext}'
 
 
 def human_filesize(size):
@@ -58,7 +58,6 @@ def read_file(archive, filename, arch):
     packages.append(basename(filename))
     return packages
 
-
 def get_packages_from_buildinfo(archive, filename, archive_entry, arch):
     buildinfo = b''.join(archive_entry.get_blocks()).decode()
     m = search('format = (\\d)', buildinfo)
@@ -68,32 +67,48 @@ def get_packages_from_buildinfo(archive, filename, archive_entry, arch):
     packages = []
     if buildinfo_format > 0:
         for package in installed:
-            pkgfilename = f'{package}.pkg.tar.xz'
+            pkgfilenames = [f'{package}.pkg{ext}' for ext in PKG_EXTENSIONS]
             pkgname = '-'.join(package.split('-')[:-3])
             if not pkgname:
                 print(f'ERROR: failed to parse {package} with format {buildinfo_format} needed for {filename}', file=stderr)
                 continue
-            directory = join(archive, 'packages', pkgname[0], pkgname)
-            path = join(directory, pkgfilename)
-            if not isfile(path):
-                print(f'ERROR: {package} needed for {filename} not in archive {path}', file=stderr)
+            directory = join(archive, 'packages'. pkgname[0], pkgname)
+            paths = [(pkgfilename, join(directory, pkgfilename)) for pkgfilename in pkgfilenames]
+            existing_paths = list(filter(lambda path_tuple: isfile(path_tuple[1]), paths))
+            if len(existing_paths) == 0:
+                for _, path in paths:
+                    print(f'ERROR: {package} needed for {filename} not in archive {path}', file=stderr)
                 continue
-            packages.append(pkgfilename)
+            packages.extend(list(map(lambda path_tuple: path_tuple[0], existing_paths)))
         return packages
     for package in installed:
-        filename_any = f'{package}-any.pkg.tar.xz'
-        filename_arch = f'{package}-{arch}.pkg.tar.xz'
+        filenames_any = [f'{package}-any.pkg{ext}' for ext in PKG_EXTENSIONS]
+        filenames_arch = [f'{package}-{arch}.pkg{ext}' for ext in PKG_EXTENSIONS]
         pkgname = '-'.join(package.split('-')[:-2])
         directory = join(archive, 'packages', pkgname[0], pkgname)
-        path_any = join(directory, filename_any)
-        path_arch = join(directory, filename_arch)
-        if isfile(path_any):
-            packages.append(filename_any)
-        elif isfile(path_arch):
-            packages.append(filename_arch)
-        else:
-            print(f'ERROR: {package} needed for {filename} not in archive {path_any}', file=stderr)
-            print(f'ERROR: {package} needed for {filename} not in archive {path_arch}', file=stderr)
+        paths_any= [(filename_any, join(directory, filename_any)) for filename_any in filenames_any]
+        paths_arch = [(filename_arch, join(directory, filename_arch)) for filename_arch in filenames_arch]
+
+        found_package = None
+        for path_any_tuple, path_arch_tuple in zip(paths_any, paths_arch):
+            filename_any, path_any = path_any_tuple
+            filename_arch, path_arch = path_arch_tuple
+            if isfile(path_any):
+                found_package = filename_any
+                break
+            elif isfile(path_arch):
+                found_package = filename_arch
+                break
+
+        if found_package is None:
+            for path_any_tuple, path_arch_tuple in zip(paths_any, paths_arch):
+                filename_any, path_any = path_any_tuple
+                filename_arch, path_arch = path_arch_tuple
+                print(f'ERROR: {package} needed for {filename} not in archive {path_any}', file=stderr)
+                print(f'ERROR: {package} needed for {filename} not in archive {path_arch}', file=stderr)
+                continue
+        packages.append(found_package)
+
     return packages
 
 
@@ -103,8 +118,9 @@ def main(repo=DEFAULT_SOURCE_DIR, archive=DEFAULT_ARCHIVE_DIR, keep_years=DEFAUL
     for subdir in SOURCE_WHITELIST:
         for arch in ARCHS:
             directory = join(repo, subdir, 'os', arch)
-            for filename in glob(join(directory, f'*{PKG_EXT}')):
-                tasks.append((archive, filename, arch))
+            for ext in PKG_EXTENSIONS:
+                for filename in glob(join(directory, f'*{ext}')):
+                    tasks.append((archive, filename, arch))
 
     with Pool(processes=processes) as pool:
         results = pool.starmap(read_file, tasks)
@@ -120,8 +136,8 @@ def main(repo=DEFAULT_SOURCE_DIR, archive=DEFAULT_ARCHIVE_DIR, keep_years=DEFAUL
     years = list(filter(lambda year: year <= keep_until,
                         map(lambda path: int(basename(path)), glob(join(archive, 'repos', '2*')))))
     purge_paths = [path for paths in [glob(join(archive, 'repos', f'{year}', '*', '*')) for year in years] for path in paths]
-    purge_paths = [join(path, '*', 'os', '*', f'*{PKG_EXT}') for path in purge_paths] + \
-                  [join(path, 'pool', '*', f'*{PKG_EXT}') for path in purge_paths]
+    purge_paths = [join(path, '*', 'os', '*', f'*{ext}') for ext in PKG_EXTENSIONS for path in purge_paths] + \
+                  [join(path, 'pool', '*', f'*{ext}') for ext in PKG_EXTENSIONS for path in purge_paths]
 
     with Pool(processes=processes) as pool:
         results = pool.map(glob, purge_paths)

--- a/archive-cleaner
+++ b/archive-cleaner
@@ -31,7 +31,7 @@ def get_sourceball(path):
     date = m.group(0)
 
     pkgname = basename(path)
-    pkg_exts = list(filter(lambda ext: ext in pkgname, PKG_EXTENSIONS))
+    pkg_exts = list(filter(lambda ext: pkgname.endswith(ext), PKG_EXTENSIONS))
     if not pkg_exts:
         raise ValueError(f'Expecting path to end with one of these extensions {" ".join(PKG_EXTENSIONS)}. {path} given')
     source_ext = f'.src{pkg_exts[0]}'
@@ -89,7 +89,7 @@ def get_packages_from_buildinfo(archive, filename, archive_entry, arch):
         filenames_arch = [f'{package}-{arch}.pkg{ext}' for ext in PKG_EXTENSIONS]
         pkgname = '-'.join(package.split('-')[:-2])
         directory = join(archive, 'packages', pkgname[0], pkgname)
-        paths_any= [join(directory, filename_any) for filename_any in filenames_any]
+        paths_any = [join(directory, filename_any) for filename_any in filenames_any]
         paths_arch = [join(directory, filename_arch) for filename_arch in filenames_arch]
 
         existing_paths_any = list(filter(lambda path: isfile(path), paths_any))
@@ -112,8 +112,8 @@ def main(repo=DEFAULT_SOURCE_DIR, archive=DEFAULT_ARCHIVE_DIR, keep_years=DEFAUL
     for subdir in SOURCE_WHITELIST:
         for arch in ARCHS:
             directory = join(repo, subdir, 'os', arch)
-            for filename in filter(lambda filename: SIG_EXT not in filename, glob(join(directory, f'*.pkg.*'))):
-                    tasks.append((archive, filename, arch))
+            for filename in filter(lambda filename: not filename.endswith(SIG_EXT), glob(join(directory, f'*.pkg.*'))):
+                tasks.append((archive, filename, arch))
 
     with Pool(processes=processes) as pool:
         results = pool.starmap(read_file, tasks)
@@ -129,13 +129,13 @@ def main(repo=DEFAULT_SOURCE_DIR, archive=DEFAULT_ARCHIVE_DIR, keep_years=DEFAUL
     years = list(filter(lambda year: year <= keep_until,
                         map(lambda path: int(basename(path)), glob(join(archive, 'repos', '2*')))))
     purge_paths = [path for paths in [glob(join(archive, 'repos', f'{year}', '*', '*')) for year in years] for path in paths]
-    purge_paths = [join(path, '*', 'os', '*', '*.pkg.*') for path in purge_paths] + \
-                  [join(path, 'pool', '*', '*.pkg.*') for path in purge_paths]
+    purge_paths = [join(path, '*', 'os', '*', '*.pkg.tar.*') for path in purge_paths] + \
+                  [join(path, 'pool', '*', '*.pkg.tar.*') for path in purge_paths]
 
     with Pool(processes=processes) as pool:
         results = pool.map(glob, purge_paths)
 
-    all_files = [path for paths in results for path in paths if SIG_EXT not in path]
+    all_files = [path for paths in results for path in paths if not path.endswith(SIG_EXT)]
     purge = list(filter(lambda path: basename(path) not in needed, all_files))
     keep = list(filter(lambda path: basename(path) in needed, all_files))
 

--- a/archive-cleaner
+++ b/archive-cleaner
@@ -31,7 +31,10 @@ def get_sourceball(path):
     date = m.group(0)
 
     pkgname = basename(path)
-    source_ext = '.src.{}'.format('.'.join(pkgname.split('.')[1:]))
+    pkg_exts = list(filter(lambda ext: ext in pkgname, PKG_EXTENSIONS))
+    if not pkg_exts:
+        raise ValueError(f'Expecting path to end with one of these extensions {" ".join(PKG_EXTENSIONS)}. {path} given')
+    source_ext = f'.src{pkg_exts[0]}'
     pkgver, pkgrel, _ = pkgname.split('-')[-3:]
     pkgname, _ = pkgname.split(f'-{pkgver}-{pkgrel}')
 
@@ -72,42 +75,33 @@ def get_packages_from_buildinfo(archive, filename, archive_entry, arch):
             if not pkgname:
                 print(f'ERROR: failed to parse {package} with format {buildinfo_format} needed for {filename}', file=stderr)
                 continue
-            directory = join(archive, 'packages'. pkgname[0], pkgname)
-            paths = [(pkgfilename, join(directory, pkgfilename)) for pkgfilename in pkgfilenames]
-            existing_paths = list(filter(lambda path_tuple: isfile(path_tuple[1]), paths))
-            if len(existing_paths) == 0:
-                for _, path in paths:
-                    print(f'ERROR: {package} needed for {filename} not in archive {path}', file=stderr)
+            directory = join(archive, 'packages', pkgname[0], pkgname)
+            paths = [join(directory, pkgfilename) for pkgfilename in pkgfilenames]
+            existing_paths = list(filter(lambda path: isfile(path), paths))
+            if not existing_paths:
+                print(f'ERROR: {package} needed for {filename} not in archive {" ".join(paths)}', file=stderr)
                 continue
-            packages.extend(list(map(lambda path_tuple: path_tuple[0], existing_paths)))
+            # as it shouldn't be possible to have more than one extension take the first and append it
+            packages.append(basename(existing_paths[0]))
         return packages
     for package in installed:
         filenames_any = [f'{package}-any.pkg{ext}' for ext in PKG_EXTENSIONS]
         filenames_arch = [f'{package}-{arch}.pkg{ext}' for ext in PKG_EXTENSIONS]
         pkgname = '-'.join(package.split('-')[:-2])
         directory = join(archive, 'packages', pkgname[0], pkgname)
-        paths_any= [(filename_any, join(directory, filename_any)) for filename_any in filenames_any]
-        paths_arch = [(filename_arch, join(directory, filename_arch)) for filename_arch in filenames_arch]
+        paths_any= [join(directory, filename_any) for filename_any in filenames_any]
+        paths_arch = [join(directory, filename_arch) for filename_arch in filenames_arch]
 
-        found_package = None
-        for path_any_tuple, path_arch_tuple in zip(paths_any, paths_arch):
-            filename_any, path_any = path_any_tuple
-            filename_arch, path_arch = path_arch_tuple
-            if isfile(path_any):
-                found_package = filename_any
-                break
-            elif isfile(path_arch):
-                found_package = filename_arch
-                break
+        existing_paths_any = list(filter(lambda path: isfile(path), paths_any))
+        existing_paths_arch = list(filter(lambda path: isfile(path), paths_arch))
 
-        if found_package is None:
-            for path_any_tuple, path_arch_tuple in zip(paths_any, paths_arch):
-                filename_any, path_any = path_any_tuple
-                filename_arch, path_arch = path_arch_tuple
-                print(f'ERROR: {package} needed for {filename} not in archive {path_any}', file=stderr)
-                print(f'ERROR: {package} needed for {filename} not in archive {path_arch}', file=stderr)
-                continue
-        packages.append(found_package)
+        if existing_paths_any:
+            # as it shouldn't be possible to have more than one extension take the first and append it
+            packages.append(basename(existing_paths_any[0]))
+        elif existing_paths_arch:
+            packages.append(basename(existing_paths_arch[0]))
+        else:
+            print(f'ERROR: {package} needed for {filename} not in archive {" ".join(paths_any + paths_arch)}', file=stderr)
 
     return packages
 
@@ -118,8 +112,7 @@ def main(repo=DEFAULT_SOURCE_DIR, archive=DEFAULT_ARCHIVE_DIR, keep_years=DEFAUL
     for subdir in SOURCE_WHITELIST:
         for arch in ARCHS:
             directory = join(repo, subdir, 'os', arch)
-            for ext in PKG_EXTENSIONS:
-                for filename in glob(join(directory, f'*{ext}')):
+            for filename in filter(lambda filename: SIG_EXT not in filename, glob(join(directory, f'*.pkg.*'))):
                     tasks.append((archive, filename, arch))
 
     with Pool(processes=processes) as pool:
@@ -136,13 +129,13 @@ def main(repo=DEFAULT_SOURCE_DIR, archive=DEFAULT_ARCHIVE_DIR, keep_years=DEFAUL
     years = list(filter(lambda year: year <= keep_until,
                         map(lambda path: int(basename(path)), glob(join(archive, 'repos', '2*')))))
     purge_paths = [path for paths in [glob(join(archive, 'repos', f'{year}', '*', '*')) for year in years] for path in paths]
-    purge_paths = [join(path, '*', 'os', '*', f'*{ext}') for ext in PKG_EXTENSIONS for path in purge_paths] + \
-                  [join(path, 'pool', '*', f'*{ext}') for ext in PKG_EXTENSIONS for path in purge_paths]
+    purge_paths = [join(path, '*', 'os', '*', '*.pkg.*') for path in purge_paths] + \
+                  [join(path, 'pool', '*', '*.pkg.*') for path in purge_paths]
 
     with Pool(processes=processes) as pool:
         results = pool.map(glob, purge_paths)
 
-    all_files = [path for paths in results for path in paths]
+    all_files = [path for paths in results for path in paths if SIG_EXT not in path]
     purge = list(filter(lambda path: basename(path) not in needed, all_files))
     keep = list(filter(lambda path: basename(path) in needed, all_files))
 


### PR DESCRIPTION
Referencing this PR https://github.com/archlinux/archivetools/pull/8 here I propose changes to the archive-cleaner script to support an hardcoded list of extensions rather than only .tar.xz.

The code just checks for all the possible extensions till it founds the one that exists.

I wasn't able to test it yet as ./archive.sh is failing to rsync from rsync://polymorf.fr/archlinux/ so I guess it would help if somebody tested it.
